### PR TITLE
[Bug] Fix TypeError bug

### DIFF
--- a/tools/dataset_converters/textrecog/rctw_converter.py
+++ b/tools/dataset_converters/textrecog/rctw_converter.py
@@ -154,9 +154,9 @@ def generate_ann(root_path, split, image_infos, preserve_vertical):
     dst_image_root = osp.join(root_path, 'crops', split)
     ignore_image_root = osp.join(root_path, 'ignores', split)
     if split == 'training':
-        dst_label_file = osp.join(root_path, f'train_label.{format}')
+        dst_label_file = osp.join(root_path, f'train_label.json')
     elif split == 'val':
-        dst_label_file = osp.join(root_path, f'val_label.{format}')
+        dst_label_file = osp.join(root_path, f'val_label.json')
     mmengine.mkdir_or_exist(dst_image_root)
     mmengine.mkdir_or_exist(ignore_image_root)
 


### PR DESCRIPTION
## Motivation
I tried to run this command to convert my rctw format dataset to the standard format.
`python tools/dataset_converters/textrecog/rctw_converter.py PATH/TO/rctw --nproc 4`

## Modification

I traced the bug and found the out_json_name was not correct.
In 'mmocr/tools/dataset_converters/textrecog/rctw_converter.py', I found variable dst_label_file was not correct.
I replaced the string 'format' into 'json' in both line 157 and line 159 then the command work!
